### PR TITLE
Fix text for the progress email

### DIFF
--- a/app/views/subscription_mailer/progress.html.haml
+++ b/app/views/subscription_mailer/progress.html.haml
@@ -1,7 +1,7 @@
 %h4= "Hello, #{@user.name}"
 %p
   Your goal for this month is
-  = link_to (@subscription.try(:goal) || @subscription.set_default_goal).name, goals_url 
+  = link_to (@subscription.try(:goal) || @subscription.set_default_goal).name, goals_url
 %p
   - if @subscription.goal_achived?
     You have achived your goal before time. Bravo! Do remember to
@@ -11,4 +11,4 @@
     Wake up and smell the coffee! Do your bit for the community please!
   - else
     Keep going, you still have some time!
-    = "You are only #{@subscription.goal.points - @subscription.points} required to achive your goal"
+    = "You are only #{@subscription.goal.points - @subscription.points} points away from reaching your goal!"


### PR DESCRIPTION
![codecuriosity you have still time to achive your goal keep it up - csonpatki gmail com - gmail 2016-08-21 10-39-25](https://cloud.githubusercontent.com/assets/621238/17835484/ff7d24d8-678b-11e6-9b1b-a1f6388055a4.jpg)

The text was 

`you still have some time! You are only 29 required to achive your goal`

Changed it to

`you still have some time! You are only 29 points away from reaching your goal!`