### PR TITLE
User links will now use slug instead of id refs #90

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find_by_slug(params[:id])
+    @user = User.find(params[:id])
     @show_transactions = current_user == @user
 
     if @user
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
 
   def update_notification
     user_params = params.fetch(:user).permit(:notify_monthly_progress, :notify_monthly_points)
-    @user = User.find_by_slug(params[:id])
+    @user = User.find(params[:id])
     @user.update(user_params)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User
   include Mongoid::Timestamps
   include GlobalID::Identification
   include UserGithubHelper
-
+  include Mongoid::Slug
   ROLES = {admin: 'Admin'}
 
   # Include default devise modules. Others available are:
@@ -67,6 +67,8 @@ class User
   has_many :redeem_requests
   has_many :group_invitations
   belongs_to :goal
+  
+  slug  :github_handle
 
   index(uid: 1)
   index(github_handle: 1)
@@ -198,10 +200,6 @@ class User
 
   def total_points
     @_t_p ||= self.transactions.sum(:points)
-  end
-
-  def self.find_by_slug(slug)
-    User.where(id: slug).first || User.where(github_handle: slug).first
   end
 
   def current_subscription(round = nil)


### PR DESCRIPTION
```mongoid-slug``` is already included in ```Gemfile```. But currently whenever link is used ```id``` is used instead of ```slug``` because ```slug``` was not defined on ```user```. 

So defined ```slug``` on ```user``` and removed ```find_by_slug``` method because now ```Mongoid::Slug``` will take care of this.