### PR TITLE
Altered gems with github paths to use https protocol to fix 'bundle' warnings.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,8 @@ gem 'omniauth-github', '~> 1.1.2'
 gem 'sidekiq', '~> 4.0'
 gem 'dotenv-rails'
 gem 'git', '~> 1.3'
-gem 'rugged', git: 'git://github.com/libgit2/rugged.git', submodules: true
-gem 'bugspots', git: 'git://github.com/igrigorik/bugspots.git'
+gem 'rugged', git: 'https://github.com/libgit2/rugged.git', submodules: true
+gem 'bugspots', git: 'https://github.com/igrigorik/bugspots.git'
 gem 'redis-rails'
 gem 'whenever', :require => false
 gem 'mongoid-slug', '~> 5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/igrigorik/bugspots.git
+  remote: https://github.com/igrigorik/bugspots.git
   revision: 4fb960eb79e5a86b95a26f604035ab68b3992d2c
   specs:
     bugspots (0.2.1)
@@ -7,11 +7,11 @@ GIT
       rugged (>= 0.21.0)
 
 GIT
-  remote: git://github.com/libgit2/rugged.git
-  revision: 23fa66471f8d4c2cb1bca80d6dc66d58bc847a97
+  remote: https://github.com/libgit2/rugged.git
+  revision: a3eba2692de13542bb5c69147e397264f0b4f206
   submodules: true
   specs:
-    rugged (0.25.0b5)
+    rugged (0.25.0b8)
 
 GEM
   remote: https://rubygems.org/
@@ -375,5 +375,8 @@ DEPENDENCIES
   web-console (~> 2.0)
   whenever
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.12.5
+   1.13.1


### PR DESCRIPTION
Updated the github path specified in the Gemfile to point retrieve gems using https. It suppresses the warnings _The git source `git://github.com/libgit2/rugged.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure._