### PR TITLE
Avoid rate limit issue while fetching commits for scoring

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -38,7 +38,7 @@ class Commit
   end
 
   def info
-    @info ||= GITHUB.repos.commits.get(repository.owner, repository.name, sha) #rescue nil
+    @info ||= user.gh_client.repos.commits.get(repository.owner, repository.name, sha) #rescue nil
   end
 
   def max_rating


### PR DESCRIPTION
On local setup when playing around with scoring logic I got Rate Limit Exceeded Exception from Github.

This is because while fetching commits for score we were not sending authorized request. After sending authorized request it started working as expected :)