### PR TITLE
Updated the Activity Schema to accomodate event_action

### DIFF
--- a/app/models/activities_fetcher.rb
+++ b/app/models/activities_fetcher.rb
@@ -34,6 +34,7 @@ class ActivitiesFetcher
 
     user_activity = user.activities.find_or_initialize_by(gh_id: activity.id)
     user_activity.event_type = type
+    user_activity.event_action = activity.payload['action']
     user_activity.description = activity.payload[type].body
     user_activity.repo = activity.repo.name
     user_activity.ref_url = activity.payload[type].html_url

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,8 +3,16 @@ class Activity
   include Mongoid::Timestamps
   include JudgeScoringHelper
 
+  # Github event actions for Issue can be any of assigned, unassigned, labeled, unlabeled, opened, edited, closed or reopened.
+  # Refer https://developer.github.com/v3/activity/events/types/#issuesevent for more details.
+  ISSUE_ACTIONS = %W(assigned unassigned labeled unlabeled opened edited closed reopened)
+
+  # Actions ignored for scoring.
+  CONSIDERED_FOR_SCORING = %W(opened reopened)
+
   field :description,     type: String
   field :event_type,      type: String
+  field :event_action,    type: String
   field :repo,            type: String
   field :ref_url,         type: String
   field :commented_on,    type: Time
@@ -18,6 +26,8 @@ class Activity
   has_many :comments, as: :commentable
   embeds_many :scores, as: :scorable
   belongs_to :organization
+
+  scope :considered_for_scoring, -> { where(:event_action.in => CONSIDERED_FOR_SCORING) }
 
   #validates :description, uniqueness: {:scope => :commented_on}
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -22,7 +22,7 @@ class Subscription
   end
 
   def activities_score
-    self.round.activities.where(user: user).inject(0){|r, o| r + o.final_score.to_i }
+    self.round.activities.considered_for_scoring.where(user: user).inject(0){|r, o| r + o.final_score.to_i }
   end
 
   def update_points

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -39,4 +39,11 @@ class ActivityTest < ActiveSupport::TestCase
     assert_equal activity.user.activities_count, 1
   end
 
+  def consider_for_scoring_scope_should_not_retrive_closed_event_actions
+    opened_activity = create(:activity, description: Faker::Lorem.words, event_action: 'opened')
+    closed_activity = create(:activity, description: Faker::Lorem.words, event_action: 'closed')
+    assert_equal Activity.considered_for_scoring.count, 1
+    assert_equal Activity.considered_for_scoring.first, opened_activity
+  end
+
 end

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -45,7 +45,8 @@ class SubscriptionTest < ActiveSupport::TestCase
     round = create(:round)
     subscription = create(:subscription, user: user, round: round)
     activity = create_list(:activity, 3, :auto_score => 1, user:user, round: round)
-    assert_equal subscription.activities_score, 3
+    create(:activity, event_action: :closed, user: user, round: round, auto_score: 1)
+    assert_equal subscription.activities_score, 0
   end
 
   def test_update_total_points
@@ -58,19 +59,19 @@ class SubscriptionTest < ActiveSupport::TestCase
     total_points = subscription.commits_score + subscription.activities_score
     assert_equal subscription.points, total_points
   end
-  
+
   def test_no_credit_when_point_is_0
     subscription = build(:subscription, :points => 0)
     assert_not subscription.credit_points
   end
- 
+
   def test_when_points_is_greater_than_zero_credit_transaction
     subscription = build(:subscription, :points => 2)
     subscription.credit_points
     assert_not_nil subscription.transactions
   end
 
-  
+
   def test_create_credit_transaction_only_when_transaction_type_is_credit
     subscription = create(:subscription)
     subscription.create_credit_transaction('credited', 2)


### PR DESCRIPTION
1) Added event_action to the Activity model.
2) Allowed only opened and reopened issues for scoring.