### PR TITLE
Fix set goal refs #130

### DIFF
--- a/app/views/goals/_goal.html.haml
+++ b/app/views/goals/_goal.html.haml
@@ -14,8 +14,10 @@
         bonus points. 
       %li.redeem
         = raw(goal.info['redeem_text'])
-      - unless selected_goal?(goal)
         %li
-          = link_to 'Set As Goal', set_goal_users_path(goal), class: 'button'
-  - if !selected_goal?(goal) && current_user.goal == goal
-    %h4.next-month-goal Next Month Goal
+          = link_to "Set As Next Month's Goal", set_goal_users_path(goal), class: 'button'
+  - if selected_goal?(goal)
+    %h4.next-month-goal Current Month's Goal
+  - if current_user.goal == goal
+    %h4.next-month-goal Next Month's Goal
+


### PR DESCRIPTION
+ This will not allow the user to change current month's goal but it will allow user to change next month's goal as many number of times.

+ Currently, we were not able to set next month's goal as current month's goal if we have changed it by mistake.

+ Also changed button's text to reflect it will change goal for next month's
