### PR TITLE
Updated ScoringEngine#fetch_repo to delete the repo and reclone in case of Git::GitExecuteError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ services:
 
 cache: bundler
 
-sudo: false  
+sudo: false
 
 addons:
   code_climate:
     repo_token: ENV['CODECLIMATE_REPO_TOKEN']
-    
+
+before_install:
+  - ssh -vT git@github.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,3 @@ addons:
   code_climate:
     repo_token: ENV['CODECLIMATE_REPO_TOKEN']
 
-before_install:
-  - ssh -vT git@github.com

--- a/app/models/scoring_engine.rb
+++ b/app/models/scoring_engine.rb
@@ -23,10 +23,10 @@ class ScoringEngine
       rescue Git::GitExecuteError
         #delete the repo dir and clone again
         FileUtils.rm_r("#{Rails.root.join(config[:repositories]).to_s}/#{repo.id}")
-        self.git = Git.clone(repo.ssh_url, repo.id, path: Rails.root.join(config[:repositories]).to_s)
+        self.git = Git.clone("https://github.com/#{repo.owner}/#{repo.name}.git", repo.id, path: Rails.root.join(config[:repositories]).to_s)
       end
     else
-      self.git = Git.clone(repo.ssh_url, repo.id, path: Rails.root.join(config[:repositories]).to_s)
+      self.git = Git.clone("https://github.com/#{repo.owner}/#{repo.name}.git", repo.id, path: Rails.root.join(config[:repositories]).to_s)
     end
     self.git
   end

--- a/test/fixtures/dummy-commit.json
+++ b/test/fixtures/dummy-commit.json
@@ -1,0 +1,89 @@
+{
+  "sha": "6cc7ecd9306a04fa4b084c184d89b8a21b6a5854",
+  "commit": {
+    "author": {
+      "name": "Prasad Surase",
+      "email": "prasadsurase@gmail.com",
+      "date": "2016-11-14T09:18:38Z"
+    },
+    "committer": {
+      "name": "Prasad Surase",
+      "email": "prasadsurase@gmail.com",
+      "date": "2016-11-14T09:18:38Z"
+    },
+    "message": "Updated README",
+    "tree": {
+      "sha": "303ef5c7564a9f41f15ee8d3c450b6d17cd58bd3",
+      "url": "https://api.github.com/repos/prasadsurase/dummy/git/trees/303ef5c7564a9f41f15ee8d3c450b6d17cd58bd3"
+    },
+    "url": "https://api.github.com/repos/prasadsurase/dummy/git/commits/6cc7ecd9306a04fa4b084c184d89b8a21b6a5854",
+    "comment_count": 0
+  },
+  "url": "https://api.github.com/repos/prasadsurase/dummy/commits/6cc7ecd9306a04fa4b084c184d89b8a21b6a5854",
+  "html_url": "https://github.com/prasadsurase/dummy/commit/6cc7ecd9306a04fa4b084c184d89b8a21b6a5854",
+  "comments_url": "https://api.github.com/repos/prasadsurase/dummy/commits/6cc7ecd9306a04fa4b084c184d89b8a21b6a5854/comments",
+  "author": {
+    "login": "prasadsurase",
+    "id": 562052,
+    "avatar_url": "https://avatars.githubusercontent.com/u/562052?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/prasadsurase",
+    "html_url": "https://github.com/prasadsurase",
+    "followers_url": "https://api.github.com/users/prasadsurase/followers",
+    "following_url": "https://api.github.com/users/prasadsurase/following{/other_user}",
+    "gists_url": "https://api.github.com/users/prasadsurase/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/prasadsurase/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/prasadsurase/subscriptions",
+    "organizations_url": "https://api.github.com/users/prasadsurase/orgs",
+    "repos_url": "https://api.github.com/users/prasadsurase/repos",
+    "events_url": "https://api.github.com/users/prasadsurase/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/prasadsurase/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "committer": {
+    "login": "prasadsurase",
+    "id": 562052,
+    "avatar_url": "https://avatars.githubusercontent.com/u/562052?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/prasadsurase",
+    "html_url": "https://github.com/prasadsurase",
+    "followers_url": "https://api.github.com/users/prasadsurase/followers",
+    "following_url": "https://api.github.com/users/prasadsurase/following{/other_user}",
+    "gists_url": "https://api.github.com/users/prasadsurase/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/prasadsurase/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/prasadsurase/subscriptions",
+    "organizations_url": "https://api.github.com/users/prasadsurase/orgs",
+    "repos_url": "https://api.github.com/users/prasadsurase/repos",
+    "events_url": "https://api.github.com/users/prasadsurase/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/prasadsurase/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "parents": [
+    {
+      "sha": "a988878d584d57b76b09e91a13fd78b1fbff5381",
+      "url": "https://api.github.com/repos/prasadsurase/dummy/commits/a988878d584d57b76b09e91a13fd78b1fbff5381",
+      "html_url": "https://github.com/prasadsurase/dummy/commit/a988878d584d57b76b09e91a13fd78b1fbff5381"
+    }
+  ],
+  "stats": {
+    "total": 2,
+    "additions": 1,
+    "deletions": 1
+  },
+  "files": [
+    {
+      "sha": "58789ed12807428ff98605beacdb8d4ae508bcea",
+      "filename": "README.md",
+      "status": "modified",
+      "additions": 1,
+      "deletions": 1,
+      "changes": 2,
+      "blob_url": "https://github.com/prasadsurase/dummy/blob/6cc7ecd9306a04fa4b084c184d89b8a21b6a5854/README.md",
+      "raw_url": "https://github.com/prasadsurase/dummy/raw/6cc7ecd9306a04fa4b084c184d89b8a21b6a5854/README.md",
+      "contents_url": "https://api.github.com/repos/prasadsurase/dummy/contents/README.md?ref=6cc7ecd9306a04fa4b084c184d89b8a21b6a5854",
+      "patch": "@@ -1,2 +1,2 @@\n # dummy\n-to be deleted\n+to be deleted. A dummy github repository to test bugspot scoring logic."
+    }
+  ]
+}

--- a/test/models/scoring_engine_test.rb
+++ b/test/models/scoring_engine_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class ScoringEngineTest < ActiveSupport::TestCase
+  def setup
+    super
+    @round = create :round, :open
+    @repo = create :repository, name: 'dummy', owner: 'prasadsurase', ssh_url: 'git@github.com:prasadsurase/dummy.git'
+    @commit = create :commit, repository: @repo, sha: '6cc7ecd9306a04fa4b084c184d89b8a21b6a5854'
+    stub_get("/repos/prasadsurase/dummy/commits/6cc7ecd9306a04fa4b084c184d89b8a21b6a5854")
+    .to_return(body: File.read('test/fixtures/dummy-commit.json'), status: 200,
+    headers: {content_type: "application/json; charset=utf-8"})
+  end
+
+  def teardown
+    super
+    repo_path = "#{Rails.root.join(SCORING_ENGINE_CONFIG[:repositories]).to_s}/#{@repo.id}"
+    FileUtils.rm_r(repo_path)if Dir.exists?(repo_path)
+  end
+
+  def stub_get(path, endpoint = Github.endpoint.to_s)
+    stub_request(:get, endpoint + path)
+  end
+
+  test 'fetch_repo clones the repo if it doesnt exist' do
+    engine = ScoringEngine.new(@repo)
+    assert_nil = engine.git
+    refute Dir.exists?("#{Rails.root.join(engine.config[:repositories]).to_s}/#{@repo.id}")
+    engine.fetch_repo
+    assert Dir.exists?("#{Rails.root.join(engine.config[:repositories]).to_s}/#{@repo.id}")
+  end
+
+  test 'fetch_repo updates the repo if it exists' do
+    engine = ScoringEngine.new(@repo)
+    refute Dir.exists?("#{Rails.root.join(engine.config[:repositories]).to_s}/#{@repo.id}")
+    engine.fetch_repo
+    assert Dir.exists?("#{Rails.root.join(engine.config[:repositories]).to_s}/#{@repo.id}")
+    # checkout to initial commit and check the master's sha.
+    engine.git.reset_hard('546c6e578c16c24b0c24546e01ba0ecedd71b3af') # initial commit
+    assert_equal '546c6e578c16c24b0c24546e01ba0ecedd71b3af', engine.git.object('master').sha
+    # pull again and confirm that thats not the latest sha(pull was successfull).
+    engine.fetch_repo
+    refute_equal '546c6e578c16c24b0c24546e01ba0ecedd71b3af', engine.git.object('master').sha
+    assert Dir.exists?("#{Rails.root.join(engine.config[:repositories]).to_s}/#{@repo.id}")
+  end
+
+  test 'fetch_repo deletes and clones the repo if it exists' do
+    engine = ScoringEngine.new(@repo)
+    refute Dir.exists?("#{Rails.root.join(engine.config[:repositories]).to_s}/#{@repo.id}")
+    engine.fetch_repo
+    assert Dir.exists?("#{Rails.root.join(engine.config[:repositories]).to_s}/#{@repo.id}")
+    # checkout to initial commit and check the master's sha.
+    engine.git.reset_hard('546c6e578c16c24b0c24546e01ba0ecedd71b3af') # initial commit
+    assert_equal '546c6e578c16c24b0c24546e01ba0ecedd71b3af', engine.git.object('master').sha
+    Git::Base.any_instance.stubs(:pull).with('origin', 'master').raises(Git::GitExecuteError, {})
+    #FileUtils.expects(:rm_r).with("#{Rails.root.join(engine.config[:repositories]).to_s}/#{@repo.id}").returns(true)
+    engine.fetch_repo
+    assert Dir.exists?("#{Rails.root.join(engine.config[:repositories]).to_s}/#{@repo.id}")
+    # pull again and confirm that thats not the latest sha (deletion and clone was successfull).
+    refute_equal '546c6e578c16c24b0c24546e01ba0ecedd71b3af', engine.git.object('master').sha
+  end
+
+  test 'bugspots_score returns 0 if commit info is not present' do
+    Commit.any_instance.stubs(:info).returns(nil)
+    engine = ScoringEngine.new(@repo)
+    assert_equal 0, engine.bugspots_score(@commit)
+  end
+
+  test 'bugspots_score of unwanted files should always be 0' do
+    skip 'needs implementation'
+    assert INVALID_FILES.include?('Gemfile.lock')
+    engine = ScoringEngine.new(@repo)
+    engine.bugspots_score(@commit)
+  end
+end


### PR DESCRIPTION
[git pull](https://github.com/joshsoftware/code-curiosity/blob/master/app/models/scoring_engine.rb#L21) in [ScoringEngine#fetch_repo](https://github.com/joshsoftware/code-curiosity/blob/master/app/models/scoring_engine.rb#L13) fails if the repo has merge conflicts from previous pull and hence the Git::GitExecuteError. Since we can't resolve the conflicts, we delete the repo and clone it again. Refer rollbar#114.