### PR TITLE
Soft delete repositories.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'whenever', :require => false
 gem 'mongoid-slug', '~> 5.2'
 gem 'redcarpet'
 gem 'rollbar'
+gem 'mongoid-paranoia'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,9 @@ GEM
     mongoid-compatibility (0.4.0)
       activesupport
       mongoid (>= 2.0)
+    mongoid-paranoia (2.0.0)
+      activesupport (~> 4.0)
+      mongoid (>= 4.0.0, <= 6.0.0)
     mongoid-slug (5.2.0)
       mongoid (>= 3.0)
       mongoid-compatibility
@@ -401,6 +404,7 @@ DEPENDENCIES
   minitest-rails-capybara
   mocha
   mongoid (~> 5.0)
+  mongoid-paranoia
   mongoid-slug (~> 5.2)
   omniauth-github (~> 1.1.2)
   poltergeist

--- a/app/jobs/user_repos_job.rb
+++ b/app/jobs/user_repos_job.rb
@@ -26,12 +26,13 @@ class UserReposJob < ActiveJob::Base
     if repo
       if repo.info.stargazers_count < REPOSITORY_CONFIG['popular']['stars']
         # soft delete the repository if the star rating has declined.
+        repo.set(stars: gh_repo.stargazers_count)
         repo.destroy
       else
         # restore the repo if the repository was already soft deleted and the current star count is greater then the threshold
         repo.restore if repo.destroyed?
+        repo.set(stars: repo.info.stargazers_count)
       end
-
       repo.users << user unless repo.users.include?(user)
       return
     end

--- a/app/jobs/user_repos_job.rb
+++ b/app/jobs/user_repos_job.rb
@@ -20,9 +20,18 @@ class UserReposJob < ActiveJob::Base
   end
 
   def add_repo(gh_repo)
-    repo = Repository.where(gh_id: gh_repo.id).first
+    #check if the repository is not soft deleted and
+    repo = Repository.unscoped.where(gh_id: gh_repo.id).first
 
     if repo
+      if repo.info.stargazers_count < REPOSITORY_CONFIG['popular']['stars']
+        # soft delete the repository if the star rating has declined.
+        repo.destroy
+      else
+        # restore the repo if the repository was already soft deleted and the current star count is greater then the threshold
+        repo.restore if repo.destroyed?
+      end
+
       repo.users << user unless repo.users.include?(user)
       return
     end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -3,6 +3,7 @@ class Repository
   include Mongoid::Timestamps
   include GlobalID::Identification
   include RepoLeaders
+  include Mongoid::Paranoia
 
   field :name,         type: String
   field :description,  type: String

--- a/test/jobs/user_repos_job_test.rb
+++ b/test/jobs/user_repos_job_test.rb
@@ -115,6 +115,8 @@ class UserReposJobTest < ActiveJob::TestCase
   test 'destroy the repository if it is already persisted if the rating has dropped' do
     repo = create :repository, name: 'code-curiosity', ssh_url: 'git@github.com:prasadsurase/code-curiosity.git',
       owner: 'prasadsurase', stars: 26, gh_id: 67219068
+    @user.repositories << repo
+    @user.save
     User.any_instance.stubs(:fetch_all_github_repos).returns(
       JSON.parse(File.read('test/fixtures/repos.json')).collect{|i| Hashie::Mash.new(i)}
     )
@@ -123,19 +125,22 @@ class UserReposJobTest < ActiveJob::TestCase
     )
     assert_nil repo.deleted_at
     assert_equal 1, Repository.count
+    assert_equal 26, repo.stars
     UserReposJob.perform_now(@user)
     repo.reload
     refute_nil repo.deleted_at
     assert repo.destroyed?
-    assert_equal 26, repo.stars
-    assert_equal 24, repo.info.stargazers_count
-    assert_equal 0, Repository.count
     assert_equal 1, Repository.unscoped.count
+    assert_equal 0, Repository.count
+    assert_equal 24, repo.info.stargazers_count
+    assert_equal 24, repo.stars
   end
 
   test 'restore the repository if it is already persisted and destroyed if the rating has increased' do
     repo = create :repository, name: 'code-curiosity', ssh_url: 'git@github.com:prasadsurase/code-curiosity.git',
       owner: 'prasadsurase', stars: 24, gh_id: 67219068, deleted_at: Time.now - 2.days
+    @user.repositories << repo
+    @user.save
     User.any_instance.stubs(:fetch_all_github_repos).returns(
       JSON.parse(File.read('test/fixtures/repos.json')).collect{|i| Hashie::Mash.new(i)}
     )
@@ -144,16 +149,17 @@ class UserReposJobTest < ActiveJob::TestCase
     )
     refute_nil repo.deleted_at
     assert repo.destroyed?
+    assert_equal 24, repo.stars
     assert_equal 0, Repository.count
     assert_equal 1, Repository.unscoped.count
     UserReposJob.perform_now(@user)
     repo.reload
-    assert_nil repo.deleted_at
     refute repo.destroyed?
-    assert_equal 24, repo.stars
-    assert_equal 25, repo.info.stargazers_count
-    assert_equal 1, Repository.count
+    assert_nil repo.deleted_at
     assert_equal 1, Repository.unscoped.count
+    assert_equal 1, Repository.count
+    assert_equal 25, repo.info.stargazers_count
+    assert_equal 25, repo.stars
   end
 
 end

--- a/test/jobs/user_repos_job_test.rb
+++ b/test/jobs/user_repos_job_test.rb
@@ -112,4 +112,48 @@ class UserReposJobTest < ActiveJob::TestCase
     assert_nil parent_repo.source_gh_id
   end
 
+  test 'destroy the repository if it is already persisted if the rating has dropped' do
+    repo = create :repository, name: 'code-curiosity', ssh_url: 'git@github.com:prasadsurase/code-curiosity.git',
+      owner: 'prasadsurase', stars: 26, gh_id: 67219068
+    User.any_instance.stubs(:fetch_all_github_repos).returns(
+      JSON.parse(File.read('test/fixtures/repos.json')).collect{|i| Hashie::Mash.new(i)}
+    )
+    Repository.any_instance.stubs(:info).returns(
+      Hashie::Mash.new(JSON.parse(File.read('test/fixtures/user-fork-repo.json')))
+    )
+    assert_nil repo.deleted_at
+    assert_equal 1, Repository.count
+    UserReposJob.perform_now(@user)
+    repo.reload
+    refute_nil repo.deleted_at
+    assert repo.destroyed?
+    assert_equal 26, repo.stars
+    assert_equal 24, repo.info.stargazers_count
+    assert_equal 0, Repository.count
+    assert_equal 1, Repository.unscoped.count
+  end
+
+  test 'restore the repository if it is already persisted and destroyed if the rating has increased' do
+    repo = create :repository, name: 'code-curiosity', ssh_url: 'git@github.com:prasadsurase/code-curiosity.git',
+      owner: 'prasadsurase', stars: 24, gh_id: 67219068, deleted_at: Time.now - 2.days
+    User.any_instance.stubs(:fetch_all_github_repos).returns(
+      JSON.parse(File.read('test/fixtures/repos.json')).collect{|i| Hashie::Mash.new(i)}
+    )
+    Repository.any_instance.stubs(:info).returns(
+      Hashie::Mash.new(JSON.parse(File.read('test/fixtures/repo.json')))
+    )
+    refute_nil repo.deleted_at
+    assert repo.destroyed?
+    assert_equal 0, Repository.count
+    assert_equal 1, Repository.unscoped.count
+    UserReposJob.perform_now(@user)
+    repo.reload
+    assert_nil repo.deleted_at
+    refute repo.destroyed?
+    assert_equal 24, repo.stars
+    assert_equal 25, repo.info.stargazers_count
+    assert_equal 1, Repository.count
+    assert_equal 1, Repository.unscoped.count
+  end
+
 end


### PR DESCRIPTION
If an existing repo's stars rating has decreased below the threshold, soft delete the repository. If an already deleted repository's rating has increased above the threshold, restore the repository. In both cases, update the repo's stars with the latest count.