### PR TITLE
Fixed "RegexpError: premature end of char-class:" issue.

### DIFF
--- a/app/models/file_to_be_ignored.rb
+++ b/app/models/file_to_be_ignored.rb
@@ -9,7 +9,10 @@ class FileToBeIgnored
 
   def self.name_exist?(file_path)
     file_name = File.basename(file_path)
-    where(name: /#{file_name}$/).any?
+
+    return false if file_name.blank?
+
+    where(name: /(#{Regexp.escape(file_name)})$/).any?
   end
 
 end

--- a/test/models/file_to_be_ignored_test.rb
+++ b/test/models/file_to_be_ignored_test.rb
@@ -39,6 +39,11 @@ class FileToBeIgnoredTest < ActiveSupport::TestCase
     assert_not FileToBeIgnored.name_exist?("config/application.rb")
   end
 
+  test 'file name contains brackets or special characters' do
+    file_1 = create :file_to_be_ignored, name: "Gemfile.lock", programming_language: "ruby"
+    assert_not FileToBeIgnored.name_exist?("thredds/dap4/d4tests/src/test/data/resources/TestHyrax/][")
+  end
+
   test 'folder path is present in the ignore list' do
   end
 


### PR DESCRIPTION
For commits like [this](https://github.com/lesserwhirls/thredds/blob/5.0.0/dap4/d4tests/src/test/data/resources/TestHyrax/%5D%5B) , which have filename as **][** we are getting **RegexpError: premature end of char-class: /][$**/ error.