### PR TITLE
Removed soft deletion fo the repo since it breaks the HABTM associations

### DIFF
--- a/app/views/activities/_commit.html.haml
+++ b/app/views/activities/_commit.html.haml
@@ -1,7 +1,7 @@
 %tr{data: {commit: commit.id.to_s}}
   = render partial: 'activities/score_cell', locals: { resource: commit }
   %td= commit.commit_date.strftime('%d/%b/%Y')
-  %td= commit.repository.name
+  %td= commit.repository.try(:name)
   %td= commit.message
   %td
     = link_to commit.html_url, target: '_blank', class: 'btn btn-block btn-default btn-xs' do

--- a/lib/tasks/utils.rake
+++ b/lib/tasks/utils.rake
@@ -59,4 +59,17 @@ namespace :utils do
     end
   end
 
+  desc "Restore Repository and associated user"
+  task restore_repositories: :environment do
+    # get all deleted repositories
+    Repository.deleted.each do |deleted_repo|
+      # get the users for the deleted repository and recreate the relationship
+      deleted_repo.users.each do |user|
+        user.repositories << deleted_repo
+      end
+      # restore the repository.
+      deleted_repo.restore
+    end
+  end
+
 end

--- a/test/jobs/user_repos_job_test.rb
+++ b/test/jobs/user_repos_job_test.rb
@@ -113,6 +113,7 @@ class UserReposJobTest < ActiveJob::TestCase
   end
 
   test 'destroy the repository if it is already persisted if the rating has dropped' do
+    skip 'unscoped association not supported for soft deleted repo'
     repo = create :repository, name: 'code-curiosity', ssh_url: 'git@github.com:prasadsurase/code-curiosity.git',
       owner: 'prasadsurase', stars: 26, gh_id: 67219068
     @user.repositories << repo
@@ -137,6 +138,7 @@ class UserReposJobTest < ActiveJob::TestCase
   end
 
   test 'restore the repository if it is already persisted and destroyed if the rating has increased' do
+    skip 'unscoped association not supported for soft deleted repo'
     repo = create :repository, name: 'code-curiosity', ssh_url: 'git@github.com:prasadsurase/code-curiosity.git',
       owner: 'prasadsurase', stars: 24, gh_id: 67219068, deleted_at: Time.now - 2.days
     @user.repositories << repo


### PR DESCRIPTION
refs #224

Soft deletion of an object using mongoid-paranoia removes the object's id from the HABTM associations which shouldn't happen. These associations have to be created explicitly when restoring the deleted object.

Run 'bundle exec rake utils:restore_repositories RAILS_ENV=production --trace' to restore the deleted repositories.
