### PR TITLE
Fixed bug: ScroringEngine#fetch_repo doesn't retrieve the commit's branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'simple_form', '~> 3.2.1'
 gem 'omniauth-github', '~> 1.1.2'
 gem 'sidekiq', '~> 4.0'
 gem 'dotenv-rails'
-gem 'git', '~> 1.3'
+gem 'git', git: 'https://github.com/prasadsurase/ruby-git.git', branch: 'get-branches-having-a-commit'
 gem 'rugged', git: 'https://github.com/libgit2/rugged.git', submodules: true
 gem 'bugspots', git: 'https://github.com/igrigorik/bugspots.git'
 gem 'redis-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,13 @@ GIT
   specs:
     rugged (0.25.0b8)
 
+GIT
+  remote: https://github.com/prasadsurase/ruby-git.git
+  revision: 1f26c1c4cc50f183a54ce1e42efcc3762fbdaaa1
+  branch: get-branches-having-a-commit
+  specs:
+    git (1.3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -119,7 +126,6 @@ GEM
       multipart-post (>= 1.2, < 3)
     font-awesome-rails (4.6.3.1)
       railties (>= 3.2, < 5.1)
-    git (1.3.0)
     github_api (0.14.5)
       addressable (~> 2.4.0)
       descendants_tracker (~> 0.0.4)
@@ -388,7 +394,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.0)
   faker (~> 1.6.1)
   font-awesome-rails
-  git (~> 1.3)
+  git!
   github_api (~> 0.13)
   haml
   haml-rails

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,7 @@ require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"
 require "minitest/rails"
 require "webmock/minitest"
-require 'mocha/mini_test'
+require "mocha/mini_test"
 
 # To add Capybara feature tests add `gem "minitest-rails-capybara"`
 # to the test group in the Gemfile and uncomment the following:


### PR DESCRIPTION
Modified ScoringEngine#fetch_repo to accept an optional branch name and checkout to that branch prior to 'git pull' avoiding pull across branch. Modified ScoringEngine#bugspots_score to retrieve the branch which holds the commit and pass the branch name to ScoringEngine#fetch_repo.