### PR TITLE
refs #236 Added pagination option when fetching branches of a repository.

### DIFF
--- a/app/models/commits_fetcher.rb
+++ b/app/models/commits_fetcher.rb
@@ -9,7 +9,7 @@ class CommitsFetcher
   end
 
   def fetch(type = :daily)
-    user.gh_client.repos.branches(user: repo.owner, repo: repo.name).each do |branch|
+    user.gh_client.repos.branches(repo.owner, repo.name, {auto_pagination: true}).each do |branch|
       # Refer to issue https://rollbar.com/JoshSoftware/CodeCuriosity/items/8/
       # This is a quick fix where we ignore branches / repos that have moved.
       # This is related to https://github.com/piotrmurach/github/pull/258 and


### PR DESCRIPTION
Fixed bug: The api call to retrieve the branches of a github repository only retrieves 30 branches. Enabled auto_pagination option to retrieve all the branches of an repository.