### PR TITLE
Updated Commit#info

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -41,7 +41,7 @@ class Commit
   end
 
   def info
-    @info ||= user.gh_client.repos.commits.get(repository.owner, repository.name, sha) #rescue nil
+    @info ||= repository ? user.gh_client.repos.commits.get(repository.owner, repository.name, sha) : nil
   end
 
   def max_rating
@@ -51,7 +51,7 @@ class Commit
   private
 
   def set_round
-    # FIXME: This code was added to address a corner case for commits appearing in next round 
+    # FIXME: This code was added to address a corner case for commits appearing in next round
     # instead of the last month. However, it will impact scoring and bonus points. Keeping this
     # line commented in case we find a better fix. - Gautam
 

--- a/test/models/commit_test.rb
+++ b/test/models/commit_test.rb
@@ -44,6 +44,9 @@ class CommitTest < ActiveSupport::TestCase
   def test_commit_info
     commit = create(:commit, message: Faker::Lorem.sentences, sha: 'eb0df748bbf084ca522f5ce4ebcf508d16169b96', repository: create(:repository, owner: 'joshsoftware', name: 'code-curiosity'))
     assert_not_nil commit.info
+
+    commit = create(:commit, message: Faker::Lorem.sentences, sha: 'eb0df748bbf084ca522f5ce4ebcf508d16169b96', repository: nil)
+    assert_nil commit.info
   end
 
   def test_round_is_present


### PR DESCRIPTION
Request the commit info from Github only if the commit's repository is present. We delete the repository in Jobs if the repository is not found.