### PR TITLE
Fixed redemption issue

### DIFF
--- a/app/models/redemption_transaction.rb
+++ b/app/models/redemption_transaction.rb
@@ -1,0 +1,10 @@
+class RedemptionTransaction
+  include Mongoid::Document
+
+  field :round_points, type: Integer, default: 0
+  field :royalty_points, type: Integer, default: 0
+  field :goal_bonus_points, type: Integer, default: 0
+  field :round_name, type: String 
+  
+  belongs_to :transaction
+end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -12,6 +12,7 @@ class Transaction
   belongs_to :user
   belongs_to :subscription
   belongs_to :redeem_request
+  has_one :redemption_transaction
 
   validates :type, :points , presence: true
   validates :type, inclusion: { in: %w(credit debit) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -220,5 +220,3 @@ class User
     self.transactions.where(transaction_type: 'royalty_bonus').first
   end
 end
-
-

--- a/test/mailers/redeem_mailer_test.rb
+++ b/test/mailers/redeem_mailer_test.rb
@@ -5,6 +5,7 @@ class RedeemMailerTest < ActionMailer::TestCase
 
   def test_mail_is_enqueued_to_be_delivered_later
     user = create(:user)
+    round_1 = create :round, status: "open", name: Date.today.beginning_of_month.strftime("%b %Y"), from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     transaction = create(:transaction, :type => 'credit', :points => 20, user: user)
     r = create(:redeem_request, :points => 2, user: user)
     assert_enqueued_jobs 1 do 
@@ -14,6 +15,7 @@ class RedeemMailerTest < ActionMailer::TestCase
 
   def test_mail_should_be_delivered
     user = create(:user)
+    round_1 = create :round, status: "open", name: Date.today.beginning_of_month.strftime("%b %Y"), from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     transaction = create(:transaction, :type => 'credit', :points => 20, user: user)
     r = create(:redeem_request, :points => 2, user: user)
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
@@ -23,6 +25,7 @@ class RedeemMailerTest < ActionMailer::TestCase
 
   def test_mail_is_delivered_with_expected_content 
     user = create(:user)
+    round_1 = create :round, status: "open", name: Date.today.beginning_of_month.strftime("%b %Y"), from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     transaction = create(:transaction, :type => 'credit', :points => 20, user: user)
     r = create(:redeem_request, :points => 2, user: user)
     perform_enqueued_jobs do 

--- a/test/models/redeem_request_test.rb
+++ b/test/models/redeem_request_test.rb
@@ -56,6 +56,7 @@ class RedeemRequestTest < ActiveSupport::TestCase
 
   test "user total points must be greater than or equal to redeemption points" do
     user = create(:user)
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     royalty_transaction = create :transaction, points: 10, transaction_type: 'royalty_bonus', type: 'credit', user: user
     transaction = create(:transaction, :points => 4, :type => 'credit', user: user)
     redeem_request = create(:redeem_request, :points => 3, :address => 'baner', :retailer => 'github', user: user)
@@ -79,6 +80,7 @@ class RedeemRequestTest < ActiveSupport::TestCase
 
   test "points must be in multiple of hundred for redeemption" do
     user = create(:user)
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     royalty_transaction = create :transaction, points: 20, transaction_type: 'royalty_bonus', type: 'credit', user: user
     transaction = create(:transaction, :points => 100, :type => 'credit', user: user)
     redeem_request = create(:redeem_request, :points => 2, user: user)
@@ -87,6 +89,7 @@ class RedeemRequestTest < ActiveSupport::TestCase
 
   test "creating redeem_request must create redeem_transaction" do
     user = create(:user, :points => 3)
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     royalty_transaction = create :transaction, points: 10, transaction_type: 'royalty_bonus', type: 'credit', user: user
     transaction = create(:transaction, :type => 'credit', :points => 5, user: user)
     redeem_request = create(:redeem_request, :points => 2, user: user)
@@ -96,6 +99,7 @@ class RedeemRequestTest < ActiveSupport::TestCase
   
   test "transaction corresponding to redeem request must be destroyed when it is deleted" do
     user = create(:user)
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     assert_equal user.transactions.count, 0
     royalty_transaction = create :transaction, points: 10, transaction_type: 'royalty_bonus', type: 'credit', user: user
     transaction = create(:transaction, :type => 'credit', :points => 4, user: user)
@@ -110,6 +114,7 @@ class RedeemRequestTest < ActiveSupport::TestCase
  
   test "send notification only when coupon_code or comment is changed" do
     user = create(:user)
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     assert_equal user.transactions.count, 0
     royalty_transaction = create :transaction, points: 100, transaction_type: 'royalty_bonus', type: 'credit', user: user
     transaction = create(:transaction, :type => 'credit', :points => 4, user: user)
@@ -121,6 +126,7 @@ class RedeemRequestTest < ActiveSupport::TestCase
 
   test "redeem request must be updated when coupon_code or comment_changed" do
     user = create(:user)
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     assert_equal user.transactions.count, 0
     royalty_transaction = create :transaction, points: 20, transaction_type: 'royalty_bonus', type: 'credit', user: user
     transaction = create(:transaction, :type => 'credit', :points => 4, user: user)
@@ -144,9 +150,10 @@ class RedeemRequestTest < ActiveSupport::TestCase
 
   test "user should be able to redeem if user total points is greater than or equal to redemption points" do
     user = create :user
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     royalty_points = 10
     royalty_transaction = create :transaction, points: royalty_points, transaction_type: 'royalty_bonus', type: 'credit', user: user
-    round_transaction = create :transaction, points: 300, type: 'credit', user: user
+    round_transaction = create :transaction, points: 300, type: 'credit', transaction_type: 'Round', user: user
     assert_equal 2, user.transactions.count
     redeem_request = create :redeem_request, points: 300, user: user
     assert_equal 1, user.reload.redeem_requests.count
@@ -158,9 +165,10 @@ class RedeemRequestTest < ActiveSupport::TestCase
 
   test "user should be able to redeem if user points is zero and user royalty_bonus is present" do
     user = create :user
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     royalty_points = 500
     royalty_transaction = create :transaction, points: royalty_points, transaction_type: 'royalty_bonus', type: 'credit', user: user
-    round_transaction = create :transaction, points: 0, type: 'credit', user: user
+    round_transaction = create :transaction, points: 0, type: 'credit',transaction_type: 'Round', user: user
     assert_equal 2, user.transactions.count
     assert_equal 500, user.total_points
     redeem_request = create :redeem_request, points: 500, user: user
@@ -172,9 +180,10 @@ class RedeemRequestTest < ActiveSupport::TestCase
 
   test "user should not be able to redeem if redemption points is greater than 500 and user points is zero" do
     user = create :user
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     royalty_points = 1500
     royalty_transaction = create :transaction, points: royalty_points, transaction_type: 'royalty_bonus', type: 'credit', user: user
-    round_transaction = create :transaction, points: 0, type: 'credit', user: user
+    round_transaction = create :transaction, points: 0, type: 'credit', transaction_type: 'Round', user: user
     redeem_request = build :redeem_request, points: 1000, user: user
     redeem_request.save
     assert_not_empty redeem_request.errors[:points]
@@ -184,9 +193,10 @@ class RedeemRequestTest < ActiveSupport::TestCase
 
   test "user should be able to redeem multiple times but overall atmost 500 royalty_points can be redeemed in a month" do
     user = create :user
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
     royalty_points = 1000
     royalty_transaction = create :transaction, points: royalty_points, transaction_type: 'royalty_bonus', type: 'credit', user: user
-    round_transaction = create :transaction, points: 1000, type: 'credit', user: user
+    round_transaction = create :transaction, points: 1000, type: 'credit', transaction_type: 'Round', user: user
     redeem_request = create :redeem_request, points: 1300, user: user
     assert_equal 1, user.redeem_requests.count
     assert_equal 1300, user.redeem_requests.first.points
@@ -197,4 +207,35 @@ class RedeemRequestTest < ActiveSupport::TestCase
     user.instance_variable_set(:@_t_p, nil)
     assert_equal 500, user.total_points
   end
+
+
+  test "user should be able to redeem atmost 500 royalty points in each and every round if redemption criteria is satisified" do
+    user = create :user
+    round_1 = create :round, status: "open", name: Date.today.beginning_of_month.strftime("%b %Y"), from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
+    subscription = create(:subscription, user: user, round: round_1)
+    royalty_points = 3308
+    royalty_transaction = create :transaction, points: royalty_points, transaction_type: 'royalty_bonus', type: 'credit', user: user
+    round_transaction = create :transaction, points: 10, type: 'credit', user: user
+
+    redeem_request_1 = create :redeem_request, points: 100, user: user
+    user.instance_variable_set(:@_t_p, nil)
+    redeem_request_2 = create :redeem_request, points: 400, user: user
+    user.instance_variable_set(:@_t_p, nil)
+
+    Round.destroy_all
+    round_2 = create :round, status: "open", name: Date.today.next_month.beginning_of_month.strftime("%b %Y"), from_date: Date.today.next_month.beginning_of_month, end_date: Date.today.next_month.end_of_month 
+    subscription = create(:subscription, user: user, round: round_2)
+    redeem_request_1 = create :redeem_request,points: 100, created_at: Date.today.next_month, user: user
+    user.instance_variable_set(:@_t_p, nil)
+    redeem_request_2 = create :redeem_request,points: 200, created_at: Date.today.next_month, user: user
+    user.instance_variable_set(:@_t_p, nil)
+
+    Round.destroy_all
+    round_3 = create :round, status: "open", name: (Date.today + 2.month).beginning_of_month.strftime("%b %Y"), from_date: (Date.today + 2.month).beginning_of_month, end_date: (Date.today + 2.month).end_of_month
+    subscription = create(:subscription, user: user, round: round_3)
+    redeem_request_1 = create :redeem_request,points: 300, created_at: Date.today + 2.month, user: user
+    user.instance_variable_set(:@_t_p, nil)
+    redeem_request_2 = create :redeem_request,points: 200, created_at: Date.today + 2.month, user: user
+  end
+
 end

--- a/test/models/redemption_transaction_test.rb
+++ b/test/models/redemption_transaction_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class RedemptionTransactionTest < ActiveSupport::TestCase
+
+  test "user have only round points" do
+    user = create :user
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
+    
+    round_transaction = create :transaction, points: 400, type: 'credit', transaction_type: 'Round', user: user
+
+    redeem_request_1 = create :redeem_request, points: 100, user: user
+    assert_equal  100, redeem_request_1.transaction.redemption_transaction.round_points
+    assert_equal  0, redeem_request_1.transaction.redemption_transaction.royalty_points
+    user.instance_variable_set(:@_t_p, nil)
+    
+    redeem_request_2 = create :redeem_request, points: 100, user: user
+    assert_equal  100, redeem_request_2.transaction.redemption_transaction.round_points
+    assert_equal  0, redeem_request_2.transaction.redemption_transaction.royalty_points
+    user.instance_variable_set(:@_t_p, nil)
+    
+    assert_equal 2, RedemptionTransaction.count
+    Round.destroy_all
+    round_2 = create :round, status: "open", name: Date.today.next_month.beginning_of_month.strftime("%b %Y"), from_date: Date.today.next_month.beginning_of_month, end_date: Date.today.next_month.end_of_month
+    redeem_request_2 = create :redeem_request, points: 200, user: user
+  end
+
+  test "user have only royalty points" do
+    user = create :user
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
+    royalty_points = 200
+
+    royalty_transaction = create :transaction, points: royalty_points, transaction_type: 'royalty_bonus', type: 'credit', user: user
+    
+    round_transaction = create :transaction, points: 0, type: 'credit', transaction_type: 'Round', user: user
+
+    redeem_request_1 = create :redeem_request, points: 100, user: user
+    assert_equal 100, redeem_request_1.transaction.redemption_transaction.royalty_points
+    assert_equal 0, redeem_request_1.transaction.redemption_transaction.round_points
+  end
+
+  test "user have both royalty bonus as well as round points" do
+    user = create :user
+    round_1 = create :round, status: "open", name: Date.today.beginning_of_month.strftime("%b %Y"), from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
+    royalty_points = 200
+    royalty_transaction = create :transaction, points: royalty_points, transaction_type: 'royalty_bonus', type: 'credit', user: user
+    
+    round_transaction = create :transaction, points: 200, type: 'credit', transaction_type: 'Round', user: user
+
+    redeem_request_1 = create :redeem_request, points: 100, user: user
+    assert_equal  100, redeem_request_1.transaction.redemption_transaction.round_points
+    assert_equal Date.today.beginning_of_month.strftime("%b %Y"), redeem_request_1.transaction.redemption_transaction.round_name
+    user.instance_variable_set(:@_t_p, nil)
+    
+    redeem_request_2 = create :redeem_request, points: 100, user: user
+    assert_equal  100, redeem_request_2.transaction.redemption_transaction.round_points
+    assert_equal  0, redeem_request_2.transaction.redemption_transaction.royalty_points
+    user.instance_variable_set(:@_t_p, nil)
+    
+    redeem_request_3 = create :redeem_request, points: 100, user: user
+    assert_equal  100, redeem_request_3.transaction.redemption_transaction.royalty_points
+  end
+
+  test "user have royalty bonus as well as round points and redeems few in current month and remaining in next month" do
+    user = create :user
+    round_1 = create :round, status: "open", name: Date.today.beginning_of_month.strftime("%b %Y"), from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
+    royalty_points = 700
+    royalty_transaction = create :transaction, points: royalty_points, transaction_type: 'royalty_bonus', type: 'credit', user: user
+    
+    round_transaction = create :transaction, points: 200, type: 'credit', transaction_type: 'Round', user: user
+
+    redeem_request_1 = create :redeem_request, points: 300, user: user
+    assert_equal  200, redeem_request_1.transaction.redemption_transaction.round_points
+    assert_equal  100, redeem_request_1.transaction.redemption_transaction.royalty_points
+    assert_equal Date.today.beginning_of_month.strftime("%b %Y"), redeem_request_1.transaction.redemption_transaction.round_name
+    user.instance_variable_set(:@_t_p, nil)
+    
+    redeem_request_2 = create :redeem_request, points: 100, user: user
+    assert_equal  0, redeem_request_2.transaction.redemption_transaction.round_points
+    assert_equal  100, redeem_request_2.transaction.redemption_transaction.royalty_points
+    user.instance_variable_set(:@_t_p, nil)
+
+    Round.destroy_all
+    round_2 = create :round, status: "open", name: Date.today.next_month.beginning_of_month.strftime("%b %Y"), from_date: Date.today.next_month.beginning_of_month, end_date: Date.today.next_month.end_of_month
+    redeem_request_1 = create :redeem_request, points: 300, user: user
+    assert_equal  300, redeem_request_1.transaction.redemption_transaction.royalty_points
+    assert_equal  0, redeem_request_1.transaction.redemption_transaction.round_points
+    assert_equal Date.today.next_month.beginning_of_month.strftime("%b %Y"), redeem_request_1.transaction.redemption_transaction.round_name
+  end
+end


### PR DESCRIPTION
As previously we were not considering 500 royalty_points redemption specific to particular round.
Now we are checking for the round based on the redeem_request created_at.