### PR TITLE
Fixed Redemption issue for 'other' type retailer

### DIFF
--- a/app/models/redeem_request.rb
+++ b/app/models/redeem_request.rb
@@ -24,6 +24,7 @@ class RedeemRequest
   validate :check_sufficient_balance, unless: :retailer_other?, on: :create
   validate :points_validations, unless: :retailer_other?
   validate :redemption_points_validations, unless: :retailer_other?, on: :create
+  validate :user_total_points, on: :create
 
   before_validation {|r| r.points = r.points.to_i }
 
@@ -35,6 +36,11 @@ class RedeemRequest
 
   after_save :send_notification
 
+  def user_total_points
+    if user.total_points == 0
+      errors.add(:gift_product_url, "insufficient balance. You have only #{user.total_points} points in your account.") if retailer_other?
+    end
+  end
 
   def self.total_points_redeemed
     where(status: true).sum(&:points)

--- a/test/models/redeem_request_test.rb
+++ b/test/models/redeem_request_test.rb
@@ -50,7 +50,7 @@ class RedeemRequestTest < ActiveSupport::TestCase
   end
 
   test "whether retailer category is other" do
-    redeem_request = build(:redeem_request, :points => 2, :address => 'baner', :retailer => 'other', :gift_product_url => Faker::Internet.url, :address => 'baner')
+    redeem_request = build(:redeem_request, :points => 2, :retailer => 'other', :gift_product_url => Faker::Internet.url, :address => 'baner')
     assert redeem_request.retailer_other?
   end
 
@@ -238,4 +238,13 @@ class RedeemRequestTest < ActiveSupport::TestCase
     redeem_request_2 = create :redeem_request,points: 200, created_at: Date.today + 2.month, user: user
   end
 
+  test "should not redeem for others retailer if user total points is 0" do
+    user = create :user
+    round_1 = create :round, status: "open", from_date: Date.today.beginning_of_month, end_date: Date.today.end_of_month
+    round_transaction = create :transaction, points: 0, type: 'credit', transaction_type: 'Round', user: user
+    redeem_request_1 = build :redeem_request, points: 0, address: 'baner', retailer: 'other', gift_product_url: Faker::Internet.url, user: user
+    redeem_request_1.valid?
+    assert_not_empty redeem_request_1.errors[:gift_product_url]
+    assert_equal redeem_request_1.errors[:gift_product_url].first, "insufficient balance. You have only 0 points in your account."
+  end
 end


### PR DESCRIPTION
For 'other' type retailer redemption request is created even though user total points is 0.