### PR TITLE
minor fix: changed contact us icon

### DIFF
--- a/app/views/application/_footer.html.haml
+++ b/app/views/application/_footer.html.haml
@@ -6,5 +6,5 @@
   %a{:href => 'http://joshsoftware.com', target: '_blank'} JoshSoftware
 %span.contact
   %a{:href => "mailto:info@codecuriosity.org?Subject=CodeCuriosity%20Feedback", :target => "_top", style: " float: right; position: relative; left: -30%; font-weight: bold;"} 
-    %i.fa.fa-phone-square
+    %i.fa.fa-envelope-square
     %span Contact Us


### PR DESCRIPTION
I think using a telephone icon in a mailto link is not a good idea. Changing it to envelope icon may make it more beautiful.... 😄 
Changed to envelope: http://fontawesome.io/icon/envelope-o/
