### PR TITLE
Refactored : == already return boolean

### DIFF
--- a/app/controllers/admin/ignored_files_controller.rb
+++ b/app/controllers/admin/ignored_files_controller.rb
@@ -63,10 +63,7 @@ class Admin::IgnoredFilesController < ApplicationController
 
   def update_ignore_field
     @ignored_file = FileToBeIgnored.where(id: params[:ignored_file_id]).first
-
-    ignored_params = (params[:ignored_value] == "true") ? true : false
-
-    @ignored_file.update_attributes(ignored: ignored_params)
+    @ignored_file.update_attributes(ignored: params[:ignored_value] == "true")
   end
 
   private


### PR DESCRIPTION
refactored code as `==` already returns bool no need to explicitly use ternary operator. Also removed extra variable as it is not use more that one.