### PR TITLE
Admin repositories page modified

### DIFF
--- a/app/controllers/admin/repositories_controller.rb
+++ b/app/controllers/admin/repositories_controller.rb
@@ -2,11 +2,11 @@ class Admin::RepositoriesController < ApplicationController
   before_action :authenticate_user!
   before_action :authenticate_admin!
   before_action :load_repository, only: [ :assign_judge, :add_judges, :update_ignore_field ]
-
   def index
     status = params[:ignored] || false
-    @repos = Repository.where(ignore: status, name: /#{params[:query]}/).
+    @repos = Repository.parent.where(ignore: status, name: /#{params[:query]}/).
     order(name: :asc).page(params[:page])
+    load_forks_count
     if request.xhr?
       respond_to do |format|
         format.js
@@ -25,6 +25,8 @@ class Admin::RepositoriesController < ApplicationController
 
   def update_ignore_field
     @repo.update_attributes(ignore: params[:ignore_value])
+    repositories = Repository.any_of({popular_repository_id: @repo.id}, {source_gh_id: @repo.gh_id})
+    repositories.update_all(ignore: params[:ignore_value]) if repositories
   end
 
   def search
@@ -33,13 +35,17 @@ class Admin::RepositoriesController < ApplicationController
       return
     end
 
-    @repos = Repository.required.where(name: /#{params[:q]}/).asc(:name).page(params[:page])
-
+    @repos = Repository.required.parent.where(name: /#{params[:q]}/).asc(:name).page(params[:page])
+    load_forks_count
     render :index
   end
 
+  def load_forks_count
+    @forks_repos_count = Repository.collection.aggregate [ { '$match' => {popular_repository_id: { '$in' => @repos.pluck(:id) }  } }, {'$group' => { '_id' => '$popular_repository_id', 'count' => { '$sum' => 1} } } ]
+  end
+
   private
-   
+
   def load_repository
     @repo = Repository.find(params[:id])
   end

--- a/app/helpers/admin/repositories_helper.rb
+++ b/app/helpers/admin/repositories_helper.rb
@@ -3,5 +3,10 @@ module Admin::RepositoriesHelper
   def check_boolean(str)
     str == "true"
   end
+
+  def child_count(id)
+    repos = @forks_repos_count.to_a.select{ |r| r['_id'] == id}
+    repos[0]['count'] unless repos.empty?
+  end
 end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -38,7 +38,7 @@ class Repository
   scope :popular, -> { where(type: 'popular') }
   scope :users_repos, -> { where(:type.ne =>  'popular') }
   scope :required, -> { where(ignore: false) }
-
+  scope :parent, -> { any_of({type: 'popular'}, {source_gh_id: nil, popular_repository_id: nil})}
   def popular?
     self.type == 'popular'
   end

--- a/app/views/admin/repositories/_repos_table.html.haml
+++ b/app/views/admin/repositories/_repos_table.html.haml
@@ -1,18 +1,22 @@
 %table.table.table-hover.table-bordered#repos
   %thead
     %tr
-      %th.col-xs-2 Name
+      %th.col-xs-2
+        Name
+        .badge Forks
       %th.col-xs-3 Description
       %th.col-xs-1 Stars
       %th.col-xs-1.5 Judges
       %th.col-xs-1 Ignored
       %th.col-xs-2 Actions
       %th.col-xs-1 To be Ignored?
-  %tbody     
+  %tbody
     - @repos.each do |repo|
       %tr
-        %td.col-xs-2 
+        %td.col-xs-2
           = link_to repo.name,  repo.source_url, target: "_blank"
+          - if repo.popular? || repo.source_gh_id.nil?
+            .badge= child_count(repo.id)
         %td.col-xs-3= repo.description
         %td.col-xs-1= repo.stars
         %td.col-xs-1.5{id: "judges_#{repo._id}"}= repo.judges_name

--- a/test/controllers/admin/repositories_controller_test.rb
+++ b/test/controllers/admin/repositories_controller_test.rb
@@ -1,21 +1,53 @@
 require "test_helper"
 
-class Admin::RepositoriesControllerTest < ActionController::TestCase 
- 
-  test "must update repository's ignore field" do
-    seed_data
-    assert_equal false, @repo.ignore 
-    xhr :patch, :update_ignore_field, { ignore_value: true, id: @repo.id }, format: :js
-    assert_response :success
-    assert_equal true, @repo.reload.ignore 
-  end
+class Admin::RepositoriesControllerTest < ActionController::TestCase
 
-  def seed_data
+  def setup
     round = create(:round, :status => 'open')
     role = create(:role, :name => 'Admin')
-    @user = create(:user, :auth_token => 'dah123rty', goal: create(:goal))
+    @user = create(:user, :auth_token => 'dah123rty', goal: create(:goal) )
     @user.roles << role
     sign_in @user
-    @repo = create(:repository)
+    @repo = create(:repository, gh_id: 123439, type: 'popular')
   end
-end  
+
+  test "must update ignore field of child and parent repository which are associated with each other through popular_repository_id" do
+    repository_1 = create :repository, popular_repository_id: @repo.id
+    assert_equal false, @repo.ignore
+    assert_equal false, repository_1.reload.ignore
+    xhr :patch, :update_ignore_field, { ignore_value: true, id: @repo.id }, format: :js
+    assert_equal true, @repo.reload.ignore
+    assert_equal true, repository_1.reload.ignore
+  end
+
+  test "must update ignore field of child and parent repository which are associated with each other through source_gh_id" do
+    repository_1 = create :repository, source_gh_id: @repo.gh_id
+    assert_equal false, @repo.ignore
+    assert_equal false, repository_1.reload.ignore
+    xhr :patch, :update_ignore_field, { ignore_value: true, id: @repo.id }, format: :js
+    assert_equal true, @repo.reload.ignore
+    assert_equal true, repository_1.reload.ignore
+  end
+
+  test "must not update any other repositories which are not ignored" do
+    repository_1 = create :repository
+    assert_equal false, @repo.ignore
+    assert_equal false, repository_1.reload.ignore
+    xhr :patch, :update_ignore_field, { ignore_value: true, id: @repo.id }, format: :js
+    assert_equal true, @repo.reload.ignore
+    assert_equal false, repository_1.reload.ignore
+  end
+
+  test "must update ignore field of parent and all its child repositories" do
+    repository_1 = create :repository, popular_repository_id: @repo.id
+    repository_2 = create :repository, source_gh_id: @repo.gh_id
+    assert_equal false, @repo.ignore
+    assert_equal false, repository_1.reload.ignore
+    assert_equal false, repository_2.reload.ignore
+    xhr :patch, :update_ignore_field, { ignore_value: true, id: @repo.id }, format: :js
+    assert_response :success
+    assert_equal true, @repo.reload.ignore
+    assert_equal true, repository_1.reload.ignore
+    assert_equal true, repository_2.reload.ignore
+  end
+end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -51,4 +51,27 @@ class RepositoryTest < ActiveSupport::TestCase
     assert info.success?
   end
 
+  test 'must return parent repositories' do
+    repo = create :repository, type: 'popular', gh_id: 231232
+    repository_1 = create :repository, popular_repository_id: repo.id, type: nil
+    repository_2 = create :repository, source_gh_id: repo.gh_id, popular_repository_id: repo.id, type: nil
+    assert_equal 1, Repository.parent.count
+    assert_equal repo, Repository.parent.find_by(gh_id: 231232)
+  end
+
+  test 'must return child repositories whose parents are not present in DB' do
+    repo = create :repository, type: 'popular', gh_id: 231232
+    repository_1 = create :repository, type: nil
+    repository_2 = create :repository, popular_repository_id: repo.id, type: nil
+    assert_equal 2, Repository.parent.count
+    assert_not_nil Repository.parent.find(repository_1.id)
+  end
+
+  test 'must not return any child repositories whose parent are present in DB' do
+    repo = create :repository, type: 'popular', gh_id: 231232
+    repository_1 = create :repository, popular_repository_id: repo.id, type: nil
+    repository_2 = create :repository, source_gh_id: repo.gh_id, type: nil
+    assert_equal 1, Repository.parent.count
+    assert_not_nil Repository.parent.find(repo.id)
+  end
 end


### PR DESCRIPTION
Displaying only parent repositories and those forked repositories whose parent not present in DB.
Displaying forked repos count present in DB with parent repos.
Ignore all forked repos if parent repo is ignored.