### PR TITLE
change subscription of contest winners without creating sponsorer details

### DIFF
--- a/app/helpers/redeem_helper.rb
+++ b/app/helpers/redeem_helper.rb
@@ -1,5 +1,5 @@
 module RedeemHelper
   def redeem_request_value(user, one_dollar_to_points)
-    (user.is_sponsorer and user.active_sponsorer_detail) ? one_dollar_to_points : one_dollar_to_points * 2
+    (Offer.is_winner?(current_user) || (user.is_sponsorer and user.active_sponsorer_detail)) ? one_dollar_to_points : one_dollar_to_points * 2
   end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -4,11 +4,16 @@ class Offer
   field :name,               type: String, default: ""
   field :email,              type: String, default: ""
   field :active_from,        type: Date
+  field :active_till,        type: Date
 
-  validates :email, :name, :active_from, presence: true
+  validates :email, :name, :active_from, :active_till, presence: true
 
 
   def self.is_winner?(user)
-    Offer.where(:email => user.email, :active_from.lte => Date.today).present?
+    Offer.where(
+    	:email => user.email,
+    	:active_from.lte => Date.today,
+    	:active_till.gte => Date.today
+    	).present?
   end
 end

--- a/app/models/redeem_request.rb
+++ b/app/models/redeem_request.rb
@@ -143,7 +143,7 @@ class RedeemRequest
     #3 if user is on free plan he can only redeem 400 royalty points per month.
     royalty_points_threshold_check_as_per_user(total_points, royalty_points,
       redeemed_royalty_point, total_redeemed_royalty, royalty,
-      user.is_sponsorer ? REDEEM_THRESHOLD['paid'] : REDEEM_THRESHOLD['free'])
+      (Offer.is_winner?(user) || user.is_sponsorer) ? REDEEM_THRESHOLD['paid'] : REDEEM_THRESHOLD['free'])
   end
 
   # validating redeemption request limit for free and paid user
@@ -199,7 +199,7 @@ class RedeemRequest
   private
 
   def set_amount
-    denominator = if sponsorer_detail
+    denominator = if sponsorer_detail || Offer.is_winner?(user)
                     REDEEM['one_dollar_to_points']
                   else
                     REDEEM['one_dollar_to_points'] * 2
@@ -208,7 +208,7 @@ class RedeemRequest
   end
 
   def update_amount
-    denominator = if sponsorer_detail
+    denominator = if sponsorer_detail || Offer.is_winner?(user)
                     REDEEM['one_dollar_to_points']
                   else
                     REDEEM['one_dollar_to_points'] * 2

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -58,7 +58,7 @@ class Transaction
   end
 
   def set_amount
-    if user.is_sponsorer
+    if user.is_sponsorer || Offer.is_winner?(user)
       set(amount: points.to_f/SUBSCRIPTIONS['individual'])
     else
       set(amount: points.to_f/SUBSCRIPTIONS['free'])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,10 +119,6 @@ class User
     # for auto_created users, we need to invoke the after_create callback.
     user.calculate_popularity unless user.current_subscription
 
-    if Offer.is_winner?(user)
-      user.upgrade_account unless user.active_sponsorer_detail
-    end
-
     user
   end
 
@@ -277,14 +273,5 @@ class User
         self.twitter_handle = '@' + self.twitter_handle
       end
     end
-  end
-
-
-  def upgrade_account
-    sponsorer_details.create(
-      sponsorer_type: 'INDIVIDUAL',
-      subscription_status: 'active',
-      payment_plan:  SPONSOR['individual'].keys.first,
-    )
   end
 end

--- a/app/views/redeem/_new_modal.html.haml
+++ b/app/views/redeem/_new_modal.html.haml
@@ -6,7 +6,7 @@
       %h4.modal-title
         Redeem Points
         %b.pull-right.maring-right-fifty= "$1 : #{redeem_request_value(current_user, REDEEM['one_dollar_to_points'])} points"
-      - unless current_user.active_sponsorer_detail
+      - unless Offer.is_winner?(current_user) || current_user.active_sponsorer_detail
         .text-center{style: "font-size:14px"}
           %strong
             #promote

--- a/app/views/redeem/_submit_buttons.html.haml
+++ b/app/views/redeem/_submit_buttons.html.haml
@@ -1,5 +1,5 @@
 %button.btn.btn-default{'data-dismiss' => 'modal', :type => 'button'} Cancel
-- if current_user.active_sponsorer_detail
+- if Offer.is_winner?(current_user) || current_user.active_sponsorer_detail
   = f.submit "Redeem", class: "btn btn-primary"
 - else
   %button.btn.btn-primary.submit-redeem{ type: "button", data: { points: current_user.points, free: SUBSCRIPTIONS['free'], paid: SUBSCRIPTIONS['individual']} } Redeem

--- a/app/views/subscription_mailer/progress.html.haml
+++ b/app/views/subscription_mailer/progress.html.haml
@@ -16,7 +16,7 @@
     Keep going, you still have some time!
     = "You are only #{@subscription.goal.points - @subscription.points} points away from reaching your goal!"
 
-- if !@user.active_sponsorer_detail
+- if !@user.active_sponsorer_detail && !Offer.is_winner?(@user)
   %p
     %br
       %b

--- a/app/views/subscription_mailer/redeem_points.html.haml
+++ b/app/views/subscription_mailer/redeem_points.html.haml
@@ -21,7 +21,7 @@
       For more details on your points, check out your
       = link_to "CodeCuriosity profile", user_url(@user)
 
-- if !@user.active_sponsorer_detail
+- if !@user.active_sponsorer_detail && !Offer.is_winner?(@user)
   %p
     %br
       %b

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -37,14 +37,14 @@
               - else
                 %span.pull-right Not set yet
           - if logged_in_user?
-            - if @user.active_sponsorer_detail || @user.able_to_redeem?
+            - if Offer.is_winner?(current_user) || @user.active_sponsorer_detail || @user.able_to_redeem?
               = link_to '#', class: "btn btn-primary btn-block", data: { toggle: 'modal', target: '#redeem-modal .modal' } do
                 %b Redeem Points
             - else
               %span.tool-tip{"data-placement" => "top", "data-toggle" => "tooltip", :title => "Not met the redemption criteria"}
                 %span.btn.btn-primary.btn-block{:disabled => "disabled"} Redeem Points
             %p
-              - unless current_user.active_sponsorer_detail
+              - unless Offer.is_winner?(current_user) || current_user.active_sponsorer_detail
                 .text-center
                   %strong
                     #promote

--- a/test/factories/offer.rb
+++ b/test/factories/offer.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :offer do
+    name {Faker::Name.name}
+    email { Faker::Internet.email }
+    active_from Date.today.beginning_of_month
+    active_till Date.today.end_of_month
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -196,24 +196,4 @@ class UserTest < ActiveSupport::TestCase
 =end
   end
 
-  test 'upgrade account if user is offer winner' do
-    round = create :round, :open
-    offer = Offer.create(
-      email: 'test@test.com', 
-      name: 'test_user', 
-      active_from: Date.today + 5.day
-    )
-    omniauthentication
-    user = User.find_by name: 'test_user'
-    assert_equal user.active_sponsorer_detail, nil
-
-    offer.update_attributes(active_from: Date.today)
-    omniauthentication
-    assert_equal !!user.active_sponsorer_detail, true
-    assert_equal user.sponsorer_details.count, 1
-
-    omniauthentication
-    assert_equal user.sponsorer_details.count, 1
-  end
-
 end


### PR DESCRIPTION

contest winners are applied to paid subscriber plan without creating sponsorer details for that user.
so, there will no issue at the time of debiting.