### PR TITLE
Removed `Admin Redeem Request` tab from Admin side bar.

### DIFF
--- a/app/views/application/_admin_sidebar.html.haml
+++ b/app/views/application/_admin_sidebar.html.haml
@@ -16,7 +16,8 @@
       %a{href: admin_ignored_files_path}
         %i.fa.fa-circle-o
         %span Ignored Files
-    %li
-      %a{href: admin_redeem_requests_path}
-        %i.fa.fa-credit-card-alt
-        %span Redeem Requests
+    / It can be used in the future, hence commenting.
+    / %li
+    /   %a{href: admin_redeem_requests_path}
+    /     %i.fa.fa-credit-card-alt
+    /     %span Redeem Requests

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,12 +70,12 @@ Rails.application.routes.draw do
     resources :rounds, only: [:index] do
       get :mark_as_close
     end
-
-    resources :redeem_requests, only: [:index, :update, :destroy] do
-      collection do
-        get :download
-      end
-    end
+    # It can be used in the future, hence commenting.
+    # resources :redeem_requests, only: [:index, :update, :destroy] do
+    #   collection do
+    #     get :download
+    #   end
+    # end
 
     resources :ignored_files, except: [:show] do
       get :search, on: :collection


### PR DESCRIPTION
1. Removed `Admin Redeem Request` tab from Admin side bar.
2. Not removed controller code and views, as it may be required in the future.