### PR TITLE
Add gh_repo_created_at and gh_repo_updated_at fields in Repository.

### DIFF
--- a/app/jobs/user_repos_job.rb
+++ b/app/jobs/user_repos_job.rb
@@ -56,6 +56,7 @@ class UserReposJob < ActiveJob::Base
 =end
       Sidekiq.logger.info "Repository does not include this user... Adding user" unless repo.users.include?(user)
       repo.users << user unless repo.users.include?(user)
+      repo.set(gh_repo_updated_at: gh_repo.updated_at)
       return
     end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -20,6 +20,8 @@ class Repository
   field :type,         type: String
   field :ignore,       type: Boolean, default: false
   field :branches,     type: Array, default: ['master']
+  field :gh_repo_created_at, type: Time
+  field :gh_repo_updated_at, type: Time
 
   belongs_to :popular_repository, class_name: 'Repository', inverse_of: 'repositories'
   has_many :commits
@@ -98,7 +100,9 @@ class Repository
       languages: [ info.language],
       gh_id: info.id,
       ssh_url: info.ssh_url,
-      owner: info.owner.login
+      owner: info.owner.login,
+      gh_repo_created_at: info.created_at,
+      gh_repo_updated_at: info.updated_at
     })
   end
 

--- a/test/fixtures/repo.json
+++ b/test/fixtures/repo.json
@@ -1,4 +1,4 @@
-{
+[{
   "id": 67219068,
   "name": "code-curiosity",
   "full_name": "prasadsurase/code-curiosity",
@@ -264,3 +264,4 @@
   "network_count": 26,
   "subscribers_count": 1
 }
+]

--- a/test/jobs/user_repos_job_test.rb
+++ b/test/jobs/user_repos_job_test.rb
@@ -166,7 +166,7 @@ class UserReposJobTest < ActiveJob::TestCase
     assert_equal 25, repo.stars
   end
 
-  describe 'set gh_repo_updated_at' do
+  describe 'set gh_repo_updated_at and gh_repo_created_at' do
     before do
       User.any_instance.stubs(:fetch_all_github_repos).returns(
         JSON.parse(File.read('test/fixtures/repo.json'))
@@ -187,6 +187,7 @@ class UserReposJobTest < ActiveJob::TestCase
       assert_equal 0, Repository.count
       UserReposJob.perform_now(@user.id.to_s)
       assert_equal 1, Repository.count
+      assert_not_nil Repository.first.gh_repo_created_at
       assert_not_nil Repository.first.gh_repo_updated_at
     end
   end


### PR DESCRIPTION
1. gh_repo_created_at and gh_repo_updated_at are used to store the time when repository created and last updated on GitHub respectively.
2. while creating new repo object, set these fields.